### PR TITLE
fix: trigger-close logic to fire without ajax

### DIFF
--- a/assets/js/frontend/dismiss.js
+++ b/assets/js/frontend/dismiss.js
@@ -61,15 +61,20 @@ export default function dismiss() {
 						$notice.find('.courier-close').trigger('click');
 						hideNotice( notice_id );
 					} );
+
+				if ( href && href !== '#' ) {
+					$(document).ajaxComplete( function ( event, request, settings ) {
+						window.location = href;
+					} );
+				}
+
 			} else {
 				$notice.find('.courier-close').trigger('click');
 				hideNotice( notice_id );
-			}
 
-			if ( href && href !== '#' ) {
-				$(document).ajaxComplete( function ( event, request, settings ) {
+				if ( href && href !== '#' ) {
 					window.location = href;
-				} );
+				}
 			}
 		}
 	}


### PR DESCRIPTION
fix: Allow trigger-close to fire dismissal and window.location even if ajax isn't being called, add ajaxComplete method specifically to user_id after post