### PR TITLE
fix: Allow trigger-close to fire dismissal and window.location even if ajax isn't being called, add ajaxComplete method specifically to user_id after post

### DIFF
--- a/assets/js/frontend/dismiss.js
+++ b/assets/js/frontend/dismiss.js
@@ -61,15 +61,20 @@ export default function dismiss() {
 						$notice.find('.courier-close').trigger('click');
 						hideNotice( notice_id );
 					} );
+
+				if ( href && href !== '#' ) {
+					$(document).ajaxComplete( function ( event, request, settings ) {
+						window.location = href;
+					} );
+				}
+
 			} else {
 				$notice.find('.courier-close').trigger('click');
 				hideNotice( notice_id );
-			}
 
-			if ( href && href !== '#' ) {
-				$(document).ajaxComplete( function ( event, request, settings ) {
+				if ( href && href !== '#' ) {
 					window.location = href;
-				} );
+				}
 			}
 		}
 	}


### PR DESCRIPTION
Currently if a user is logged in, the .trigger-close button (a button that will redirect the user, while also closing the modal) will fire on Ajax complete with a found user ID. For a logged out user, this never fires.

This adds the else to trigger the close and the cookie for a logged out user.

This can be tested within modals with: `<a href="/page-slug/" class="trigger-close">...</a>` where it should redirect to the new page after closing the modal, and keep the modal closed on subsequent page views.