### PR TITLE
fix(NOTASK): Fix text domain notice

### DIFF
--- a/courier-notices.php
+++ b/courier-notices.php
@@ -47,7 +47,7 @@ if ( ! defined( 'COURIER_NOTICES_PLUGIN_URL' ) ) {
 }
 
 if ( ! defined( 'COURIER_NOTICES_PLUGIN_NAME' ) ) {
-	define( 'COURIER_NOTICES_PLUGIN_NAME', esc_html__( 'Courier Notices', 'courier-notices' ) );
+	define( 'COURIER_NOTICES_PLUGIN_NAME', 'Courier Notices' );
 }
 
 /**


### PR DESCRIPTION
Remove string translation that was called before init triggering text domain loading notice.