### PR TITLE
chore(NO-TASK): Use shared linchpin commitlint config

### DIFF
--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -1,43 +1,16 @@
 /**
- * Custom config for commitlint based on Linchpin needs/conventions.
+ * Commit linting for this project.
  *
- * This config only slightly modifies the default config to allow for "improve" as a type
- * and adds support for Jira, ClickUp or Github issue numbers in the commit message.
+ * The rules live in @linchpinagency/commitlint-config so every Linchpin project
+ * lints commits the same way and a convention change ships from one place
+ * instead of drifting per repo.
  *
- * Format Example
+ * Format example
  *
- * issue(COURIER-123): Add new feature
+ *   feat(PROJ-123): Add new feature
  *
- * or if you have no issue number you can utilize NO-TASK
+ * or, with no task, NO-TASK or a GitHub issue number such as #42.
  */
 module.exports = {
-	extends: ['@commitlint/config-conventional'],
-	rules: {
-		'type-enum': [
-			2,
-			'always',
-			[
-				'improve',
-				'build',
-				'chore',
-				'ci',
-				'docs',
-				'feat',
-				'fix',
-				'perf',
-				'refactor',
-				'revert',
-				'style',
-				'test',
-			],
-		],
-		'subject-case': [1, 'always', ['sentence-case']],
-	},
-	parserPreset: {
-		parserOpts: {
-			headerPattern:
-				/^(improve|build|ci|feat|fix|docs|style|revert|perf|refactor|test|chore)\(((?:COURIER-\d+)|(?:NO-JIRA|NO-TASK)|(?:\#\d+))\):\s?([\w\d\s,\-]*)/,
-			headerCorrespondence: ['type', 'scope', 'subject'],
-		},
-	},
+	extends: [ '@linchpinagency/commitlint-config' ],
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "courier-notices",
-	"version": "2.9.16",
+	"version": "1.9.18",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "courier-notices",
-			"version": "2.9.16",
+			"version": "1.9.18",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"@wordpress/url": "^4.41.0",
@@ -15,6 +15,7 @@
 			"devDependencies": {
 				"@commitlint/cli": "^19.8.1",
 				"@commitlint/config-conventional": "^19.8.1",
+				"@linchpinagency/commitlint-config": "^1.2.0",
 				"@wordpress/prettier-config": "^4.28.0",
 				"@wordpress/scripts": "^30.21.0",
 				"husky": "^9.0.11",
@@ -3344,6 +3345,20 @@
 			"integrity": "sha512-Vo+PSpZG2/fmgmiNzYK9qWRh8h/CHrwD0mo1h1DzL4yzHNSfWYujGTYsWGreD000gcgmZ7K4Ys6Tx9TxtsKdDw==",
 			"dev": true,
 			"license": "MIT"
+		},
+		"node_modules/@linchpinagency/commitlint-config": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/@linchpinagency/commitlint-config/-/commitlint-config-1.2.0.tgz",
+			"integrity": "sha512-xysTh3qrlV11nZyByHjqheDp5Jct3GHX0RNZpXoAI20lCimEMHHWjtITfRPaNzq+z4vUL9SPUzByaDCCGVQf2g==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=18"
+			},
+			"peerDependencies": {
+				"@commitlint/cli": ">=17.0.0",
+				"@commitlint/config-conventional": ">=17.0.0"
+			}
 		},
 		"node_modules/@nicolo-ribaudo/eslint-scope-5-internals": {
 			"version": "5.1.1-v1",

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
 	"devDependencies": {
 		"@commitlint/cli": "^19.8.1",
 		"@commitlint/config-conventional": "^19.8.1",
+		"@linchpinagency/commitlint-config": "^1.2.0",
 		"@wordpress/prettier-config": "^4.28.0",
 		"@wordpress/scripts": "^30.21.0",
 		"husky": "^9.0.11",


### PR DESCRIPTION
Replaces this repo's inlined commitlint rules with [`@linchpinagency/commitlint-config`](https://www.npmjs.com/package/@linchpinagency/commitlint-config), so the convention ships from one place instead of drifting per repo.

Part of an org-wide rollout. A survey of all 175 linchpin repos found **72 that lint commits, across 30 distinct config variants** — the drift this consolidates.

## Behaviour is unchanged

This repo verified as a **zero-regression** swap. Every commit in its recent history was replayed through both the old config and the shared one:

- Identical pass/fail result under each
- **Zero** commits that pass the old config and fail the new one

The shared config was deliberately widened first ([commitlint-config#4](https://github.com/linchpin/commitlint-config/pull/4)) to accept `add` and `remove`, so it is a superset of this repo's rules rather than a tightening.

## What to check

The `commit-msg` hook picks the rules up from the package after the next `npm install`.

Task: NO-TASK

🤖 Generated with [Claude Code](https://claude.com/claude-code)